### PR TITLE
use partID from raw data header for pixel unpacking

### DIFF
--- a/online/PixelUnpack.cxx
+++ b/online/PixelUnpack.cxx
@@ -72,7 +72,7 @@ Bool_t PixelUnpack::DoUnpack(Int_t *data, Int_t size)
    for (auto &&hit : hits) {
       auto hitData = reinterpret_cast<HitData *>(&(hit.hitTime));
       auto channelId = reinterpret_cast<ChannelId *>(&(hit.channelId));
-      auto detectorID = (fPartitionId%0x0800) * 10000000 + 1000000 * hitData->moduleID + 1000 * channelId->row + channelId->column;
+      auto detectorID = (df->header.partitionId%0x0800) * 10000000 + 1000000 * hitData->moduleID + 1000 * channelId->row + channelId->column;
       auto tot = hitData->tot;
       new ((*fRawData)[fNHits]) ShipPixelHit(detectorID, tot); //tot is measured in steps of 25 ns
       fNHits++;


### PR DESCRIPTION
In order for the new unpacker to consider all 3 sub partitions, the partition ID is now taken from the raw data header instead of the unpacker instance.