### PR TITLE
Add C++ and Python wrappers around fair::Logger

### DIFF
--- a/python/logger.py
+++ b/python/logger.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+import os
+import ROOT
+# TODO: add header to CMake
+ROOT.gROOT.ProcessLine('#include "' + os.path.join(os.path.expandvars('$FAIRSHIP'), 'utils', 'logger.hxx') + '"')
+
+for func in ('fatal', 'error', 'warn', 'info', 'debug'):
+    # The double lambda is used in order to capture 'func' by value, not by reference
+    # (which would always point to the last value taken in the loop)
+    globals()[func] = (lambda f:
+        lambda *args: ROOT.ship.__dict__[f](*map(type, args))(*args)
+    )(func)
+    globals()[func].__doc__ = \
+        'Python wrapper around the C++ function template ship::{}(Types... args).'.format(func)

--- a/utils/logger.hxx
+++ b/utils/logger.hxx
@@ -1,53 +1,51 @@
-#include "fairlogger/Logger.h"
+#include "FairLogger.h"
+#pragma once
 
 namespace ship {
 
 template <fair::Severity severity, class T>
 void log(T arg)
 {
-   for (bool fairLOggerunLikelyvariable = false; fair::Logger::Logging(severity) && !fairLOggerunLikelyvariable;
-        fairLOggerunLikelyvariable = true)
-      fair::Logger(severity, __FILE__, CONVERTTOSTRING(__LINE__), __FUNCTION__).Log() << arg;
+    if (fair::Logger::Logging(severity)) {
+        fair::Logger(severity, __FILE__, to_string(__LINE__), __FUNCTION__).Log() << arg;
+    }
 }
 
 template <fair::Severity severity, class T, class... Types>
 void log(T arg, Types... args)
 {
-   log<severity>(arg);
-   log<severity>(args...);
-}
-
-template <class T>
-void log(T arg)
-{
-   constexpr fair::Severity severity = fair::Severity::INFO;
-   for (bool fairLOggerunLikelyvariable = false; fair::Logger::Logging(severity) && !fairLOggerunLikelyvariable;
-        fairLOggerunLikelyvariable = true)
-      fair::Logger(severity, __FILE__, CONVERTTOSTRING(__LINE__), __FUNCTION__).Log() << arg;
+    log<severity>(arg);
+    log<severity>(args...);
 }
 
 template <class... Types>
-void warn(Types &&... args)
+void fatal(Types... args)
 {
-   log<fair::Severity::warning>(std::forward<Types>(args)...);
+    log<fair::Severity::fatal>(args...);
 }
 
 template <class... Types>
-void debug(Types &&... args)
+void error(Types... args)
 {
-   log<fair::Severity::debug>(std::forward<Types>(args)...);
+    log<fair::Severity::error>(args...);
 }
 
 template <class... Types>
-void fatal(Types &&... args)
+void warn(Types... args)
 {
-   log<fair::Severity::fatal>(std::forward<Types>(args)...);
+    log<fair::Severity::warning>(args...);
 }
 
 template <class... Types>
-void log(Types &&... args)
+void info(Types... args)
 {
-   log<fair::Severity::info>(std::forward<Types>(args)...);
+    log<fair::Severity::info>(args...);
+}
+
+template <class... Types>
+void debug(Types... args)
+{
+    log<fair::Severity::debug>(args...);
 }
 
 } // namespace ship


### PR DESCRIPTION
* The C++ wrapper consists of variadic templates in order to log an arbitrary number of objects.
  * `log(fair::Severity, Types...)` allows manually specifying the severity.
  * Convenience functions `fatal(Types...)`, `error(Types...)`, `warn(Types...)`, `info(Types...)` and `debug(Types...)` are also provided.

* The Python wrapper wraps the convenience functions `fatal`, `error`, `warn`, `info` and `debug` only. The template arguments are inferred from the Python types.

**Known issues:** for now, each argument is logged on a different line.